### PR TITLE
Refactor the script to be generic

### DIFF
--- a/Containerfile-centos-amd64
+++ b/Containerfile-centos-amd64
@@ -3,7 +3,7 @@ ARG version=stream9
 FROM quay.io/centos/centos:$version-minimal as builder
 ARG arch=x64
 ARG baseurl=https://mirror.stream.centos.org
-WORKDIR /root
+WORKDIR /work
 
 # Artifacts from kickstart repository.
 RUN . /etc/os-release && curl --location --remote-name-all --remote-time \

--- a/Containerfile-centos-amd64
+++ b/Containerfile-centos-amd64
@@ -1,0 +1,17 @@
+ARG version=stream9
+
+FROM quay.io/centos/centos:$version-minimal as builder
+ARG name=CentOS
+ARG arch=x64
+ARG baseurl=https://mirror.stream.centos.org
+WORKDIR /root
+
+# Artifacts from kickstart repository.
+RUN . /etc/os-release && curl --location --remote-name-all --remote-time \
+	${baseurl}/${VERSION}-stream/BaseOS/$(uname -m)/os/images/pxeboot/vmlinuz \
+	${baseurl}/${VERSION}-stream/BaseOS/$(uname -m)/os/images/pxeboot/initrd.img \
+	${baseurl}/${VERSION}-stream/BaseOS/$(uname -m)/os/images/install.img
+
+# Artifacts from RPM repository.
+RUN microdnf -y install shim-${arch} grub2-efi-${arch} syslinux-tftpboot
+RUN . /etc/os-release && cp -p /tftpboot/pxelinux.0 . && cp -p /boot/efi/EFI/${ID}/{shim,grub}${arch}.efi .

--- a/Containerfile-centos-amd64
+++ b/Containerfile-centos-amd64
@@ -1,7 +1,6 @@
 ARG version=stream9
 
 FROM quay.io/centos/centos:$version-minimal as builder
-ARG name=CentOS
 ARG arch=x64
 ARG baseurl=https://mirror.stream.centos.org
 WORKDIR /root

--- a/Containerfile-centos-arm64
+++ b/Containerfile-centos-arm64
@@ -1,7 +1,6 @@
 ARG version=stream9
 
 FROM quay.io/centos/centos:$version-minimal as builder
-ARG name=CentOS
 ARG arch=aa64
 ARG baseurl=https://mirror.stream.centos.org
 WORKDIR /root

--- a/Containerfile-centos-arm64
+++ b/Containerfile-centos-arm64
@@ -3,7 +3,7 @@ ARG version=stream9
 FROM quay.io/centos/centos:$version-minimal as builder
 ARG arch=aa64
 ARG baseurl=https://mirror.stream.centos.org
-WORKDIR /root
+WORKDIR /work
 
 # Artifacts from kickstart repository.
 RUN . /etc/os-release && curl --location --remote-name-all --remote-time \

--- a/Containerfile-centos-arm64
+++ b/Containerfile-centos-arm64
@@ -1,0 +1,17 @@
+ARG version=stream9
+
+FROM quay.io/centos/centos:$version-minimal as builder
+ARG name=CentOS
+ARG arch=aa64
+ARG baseurl=https://mirror.stream.centos.org
+WORKDIR /root
+
+# Artifacts from kickstart repository.
+RUN . /etc/os-release && curl --location --remote-name-all --remote-time \
+	${baseurl}/${VERSION}-stream/BaseOS/$(uname -m)/os/images/pxeboot/vmlinuz \
+	${baseurl}/${VERSION}-stream/BaseOS/$(uname -m)/os/images/pxeboot/initrd.img \
+	${baseurl}/${VERSION}-stream/BaseOS/$(uname -m)/os/images/install.img
+
+# Artifacts from RPM repository.
+RUN microdnf -y install shim-${arch} grub2-efi-${arch} syslinux-tftpboot
+RUN . /etc/os-release && cp -p /tftpboot/pxelinux.0 . && cp -p /boot/efi/EFI/${ID}/{shim,grub}${arch}.efi .

--- a/Containerfile-fedora-amd64
+++ b/Containerfile-fedora-amd64
@@ -1,6 +1,7 @@
-FROM quay.io/fedora/fedora-minimal:40 as builder
-ARG name=Fedora
 ARG version=40
+
+FROM quay.io/fedora/fedora-minimal:$version as builder
+ARG name=Fedora
 ARG arch=x64
 ARG baseurl=https://dl.fedoraproject.org/pub/fedora/linux
 WORKDIR /root

--- a/Containerfile-fedora-amd64
+++ b/Containerfile-fedora-amd64
@@ -7,10 +7,11 @@ ARG baseurl=https://dl.fedoraproject.org/pub/fedora/linux
 WORKDIR /root
 
 # Artifacts from kickstart repository.
-RUN curl -RLO ${baseurl}/releases/${version}/Everything/$(uname -m)/os/images/pxeboot/vmlinuz
-RUN curl -RLO ${baseurl}/releases/${version}/Everything/$(uname -m)/os/images/pxeboot/initrd.img
-RUN curl -RLO ${baseurl}/releases/${version}/Everything/$(uname -m)/os/images/install.img
+RUN . /etc/os-release && curl --location --remote-name-all --remote-time \
+	${baseurl}/releases/${VERSION}/Everything/$(uname -m)/os/images/pxeboot/vmlinuz \
+	${baseurl}/releases/${VERSION}/Everything/$(uname -m)/os/images/pxeboot/initrd.img \
+	${baseurl}/releases/${VERSION}/Everything/$(uname -m)/os/images/install.img
 
 # Artifacts from RPM repository.
 RUN microdnf -y install shim-${arch} grub2-efi-${arch} syslinux-tftpboot
-RUN cp -p /tftpboot/pxelinux.0 . && cp -p /boot/efi/EFI/fedora/{shim,grub${arch}}.efi .
+RUN . /etc/os-release && cp -p /tftpboot/pxelinux.0 . && cp -p /boot/efi/EFI/${ID}/{shim,grub}${arch}.efi .

--- a/Containerfile-fedora-amd64
+++ b/Containerfile-fedora-amd64
@@ -3,7 +3,7 @@ ARG version=40
 FROM quay.io/fedora/fedora-minimal:$version as builder
 ARG arch=x64
 ARG baseurl=https://dl.fedoraproject.org/pub/fedora/linux
-WORKDIR /root
+WORKDIR /work
 
 # Artifacts from kickstart repository.
 RUN . /etc/os-release && curl --location --remote-name-all --remote-time \

--- a/Containerfile-fedora-amd64
+++ b/Containerfile-fedora-amd64
@@ -1,7 +1,6 @@
 ARG version=40
 
 FROM quay.io/fedora/fedora-minimal:$version as builder
-ARG name=Fedora
 ARG arch=x64
 ARG baseurl=https://dl.fedoraproject.org/pub/fedora/linux
 WORKDIR /root

--- a/Containerfile-fedora-arm64
+++ b/Containerfile-fedora-arm64
@@ -3,7 +3,7 @@ ARG version=40
 FROM quay.io/fedora/fedora-minimal:$version as builder
 ARG arch=aa64
 ARG baseurl=https://dl.fedoraproject.org/pub/fedora/linux
-WORKDIR /root
+WORKDIR /work
 
 # Artifacts from kickstart repository.
 RUN . /etc/os-release && curl --location --remote-name-all --remote-time \

--- a/Containerfile-fedora-arm64
+++ b/Containerfile-fedora-arm64
@@ -1,7 +1,6 @@
 ARG version=40
 
 FROM quay.io/fedora/fedora-minimal:$version as builder
-ARG name=Fedora
 ARG arch=aa64
 ARG baseurl=https://dl.fedoraproject.org/pub/fedora/linux
 WORKDIR /root

--- a/Containerfile-fedora-arm64
+++ b/Containerfile-fedora-arm64
@@ -7,10 +7,11 @@ ARG baseurl=https://dl.fedoraproject.org/pub/fedora/linux
 WORKDIR /root
 
 # Artifacts from kickstart repository.
-RUN curl -RLO ${baseurl}/releases/${version}/Everything/$(uname -m)/os/images/pxeboot/vmlinuz
-RUN curl -RLO ${baseurl}/releases/${version}/Everything/$(uname -m)/os/images/pxeboot/initrd.img
-RUN curl -RLO ${baseurl}/releases/${version}/Everything/$(uname -m)/os/images/install.img
+RUN . /etc/os-release && curl --location --remote-name-all --remote-time \
+	${baseurl}/releases/${VERSION}/Everything/$(uname -m)/os/images/pxeboot/vmlinuz \
+	${baseurl}/releases/${VERSION}/Everything/$(uname -m)/os/images/pxeboot/initrd.img \
+	${baseurl}/releases/${VERSION}/Everything/$(uname -m)/os/images/install.img
 
 # Artifacts from RPM repository.
 RUN microdnf -y install shim-${arch} grub2-efi-${arch}
-RUN cp -p /boot/efi/EFI/fedora/{shim,grub${arch}}.efi .
+RUN . /etc/os-release && cp -p /boot/efi/EFI/${ID}/{shim,grub}${arch}.efi .

--- a/Containerfile-fedora-arm64
+++ b/Containerfile-fedora-arm64
@@ -1,6 +1,7 @@
-FROM quay.io/fedora/fedora-minimal:40 as builder
-ARG name=Fedora
 ARG version=40
+
+FROM quay.io/fedora/fedora-minimal:$version as builder
+ARG name=Fedora
 ARG arch=aa64
 ARG baseurl=https://dl.fedoraproject.org/pub/fedora/linux
 WORKDIR /root

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The repository is available at [quay.io/foreman/nboci-files](https://quay.io/rep
 
 Fetch files from upstream repositories. Example for Fedora OS:
 
-    podman build -v $(pwd)/work:/root:Z -f Containerfile-fedora-amd64 --platform linux/amd64
+    podman build -v $(pwd)/work:/work:Z -f Containerfile-fedora-amd64 --platform linux/amd64
 
 Where the Containerfile looks like this:
 
@@ -23,7 +23,7 @@ FROM quay.io/fedora/fedora-minimal:40 as builder
 ARG version=40
 ARG arch=x64
 ARG baseurl=https://dl.fedoraproject.org/pub/fedora/linux
-WORKDIR /root
+WORKDIR /work
 
 # Artifacts from kickstart repository.
 RUN curl -RLO ${baseurl}/releases/${version}/Everything/$(uname -m)/os/images/pxeboot/vmlinuz

--- a/README.md
+++ b/README.md
@@ -52,7 +52,14 @@ podman manifest add --all --annotation org.pulpproject.netboot.version=1 \
 
 Multiple architectures can be added into one manifest. The required annotation `org.pulpproject.netboot.version` must be present and set to `1`. Do not commit the files (e.g. `./work/*`) into the git repository.
 
-An example shell script for pushing Fedora AMD64 and ARM64 netboot files is in `push-fedora-40.sh` which can serve as a template for other Red Hat based operating systems. It is recommended to commit those build scripts into the git repository.
+This is integrated in the shell script `push`. By default it pushes Fedora 40, but can be used with other operating systems if there are Containerfiles.
+
+```console
+$ ./push
+$ OS=fedora VERSION=40 ./push # matches the previous line, but explicit
+$ OS=fedora VERSION=rawhide ./push
+$ OS=centos VERSION=stream9 ./push
+```
 
 This creates a manifest index with one or more architectures:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Where the Containerfile looks like this:
 
 ```
 FROM quay.io/fedora/fedora-minimal:40 as builder
-ARG name=Fedora
 ARG version=40
 ARG arch=x64
 ARG baseurl=https://dl.fedoraproject.org/pub/fedora/linux

--- a/push
+++ b/push
@@ -2,8 +2,9 @@
 
 shopt nullglob
 
-OS=fedora
-OSVER=fedora-40
+OS=${OS:-fedora}
+VERSION=${VERSION:-40}
+OSVER=$OS-$VERSION
 WORKDIR=$PWD/work
 REPOSITORY=${REPOSITORY:-quay.io/foreman/nboci-files}
 TAG=$REPOSITORY-$OSVER
@@ -17,11 +18,11 @@ mkdir -p "$WORKDIR"
 for containerfile in "Containerfile-$OS"-* ; do
 	ARCH=${containerfile##*-}
 	VOLUME=$(mktemp -d -p "${WORKDIR}")
-	podman build -v "${VOLUME}:/root:Z" -f "$containerfile" --platform "linux/$ARCH"
+	podman build -v "${VOLUME}:/root:Z" -f "$containerfile" --platform "linux/$ARCH" --build-arg "version=$VERSION"
 
 	# create and add netboot artifacts to the image index
 	podman manifest add --annotation org.pulpproject.netboot.version=1 \
-	    --os linux --arch "$ARCH" --os-version $OSVER \
+	    --os linux --arch "$ARCH" --os-version "$OSVER" \
 	    --artifact \
 	    --artifact-type application/vnd.org.pulpproject.netboot.artifact.v1 \
 	    --artifact-layer-type application/x-netboot-file \

--- a/push
+++ b/push
@@ -18,7 +18,7 @@ mkdir -p "$WORKDIR"
 for containerfile in "Containerfile-$OS"-* ; do
 	ARCH=${containerfile##*-}
 	VOLUME=$(mktemp -d -p "${WORKDIR}")
-	podman build -v "${VOLUME}:/root:Z" -f "$containerfile" --platform "linux/$ARCH" --build-arg "version=$VERSION"
+	podman build -v "${VOLUME}:/work:Z" -f "$containerfile" --platform "linux/$ARCH" --build-arg "version=$VERSION"
 
 	# create and add netboot artifacts to the image index
 	podman manifest add --annotation org.pulpproject.netboot.version=1 \

--- a/push-fedora-40.sh
+++ b/push-fedora-40.sh
@@ -40,4 +40,4 @@ podman manifest push --all --rm quay.io/foreman/nboci-files:$OSVER
 # tag child manifests
 # going to use skopeo for now https://github.com/containers/podman/issues/23599
 # Parse index image, find corresponding child manifests and tag them accordingly
-skopeo inspect docker://quay.io/foreman/nboci-files:$OSVER --raw |jq -r '.manifests.[] | "\(.platform.architecture) \(.digest)"' | while read i; do ARCH="$(echo $i | awk '{print $1}')"; DIGEST="$(echo $i | awk '{print $2}')" ; skopeo copy docker://quay.io/foreman/nboci-files@${DIGEST} docker://quay.io/foreman/nboci-files:$OSVER-${ARCH} ; done
+skopeo inspect docker://quay.io/foreman/nboci-files:$OSVER --raw |jq -r '.manifests.[] | "\(.platform.architecture) \(.digest)"' | while read -r i; do ARCH="$(echo "$i" | awk '{print $1}')"; DIGEST="$(echo "$i" | awk '{print $2}')" ; skopeo copy "docker://quay.io/foreman/nboci-files@${DIGEST}" "docker://quay.io/foreman/nboci-files:$OSVER-${ARCH}" ; done

--- a/push-fedora-40.sh
+++ b/push-fedora-40.sh
@@ -17,7 +17,7 @@ podman manifest add --annotation org.pulpproject.netboot.version=1 \
     --artifact \
     --artifact-type application/vnd.org.pulpproject.netboot.artifact.v1 \
     --artifact-layer-type application/x-netboot-file \
-    quay.io/foreman/nboci-files:$OSVER-amd64 ./work/*
+    quay.io/foreman/nboci-files:$OSVER ./work/*
 
 rm -f ./work/*
 podman build -v $(pwd)/work:/root:Z -f Containerfile-$OS-arm64 --platform linux/arm64
@@ -28,7 +28,7 @@ podman manifest add --annotation org.pulpproject.netboot.version=1 \
     --artifact \
     --artifact-type application/vnd.org.pulpproject.netboot.artifact.v1 \
     --artifact-layer-type application/x-netboot-file \
-    quay.io/foreman/nboci-files:$OSVER-arm64 ./work/*
+    quay.io/foreman/nboci-files:$OSVER ./work/*
 
 rm -rf ./work/
 # push image index containing netboot artifacts for different arches

--- a/push-fedora-40.sh
+++ b/push-fedora-40.sh
@@ -2,14 +2,16 @@
 
 OS=fedora
 OSVER=fedora-40
+WORKDIR=$PWD/work
 
 # create image index and set the annotation at the index level
 # TODO set the artifactType at the index level https://github.com/containers/podman/issues/23598
 podman manifest create quay.io/foreman/nboci-files:$OSVER --annotation org.pulpproject.netboot.version=1
 
-mkdir -p work
-rm -f ./work/*
-podman build -v $(pwd)/work:/root:Z -f Containerfile-$OS-amd64 --platform linux/amd64
+mkdir -p "$WORKDIR"
+VOLUME1=$(mktemp -d -p "$WORKDIR")
+
+podman build -v "${VOLUME1}:/root:Z" -f Containerfile-$OS-amd64 --platform linux/amd64
 
 # create and add netboot artifacts for amd64 to the image index
 podman manifest add --annotation org.pulpproject.netboot.version=1 \
@@ -17,10 +19,10 @@ podman manifest add --annotation org.pulpproject.netboot.version=1 \
     --artifact \
     --artifact-type application/vnd.org.pulpproject.netboot.artifact.v1 \
     --artifact-layer-type application/x-netboot-file \
-    quay.io/foreman/nboci-files:$OSVER ./work/*
+    quay.io/foreman/nboci-files:$OSVER "$VOLUME1"/*
 
-rm -f ./work/*
-podman build -v $(pwd)/work:/root:Z -f Containerfile-$OS-arm64 --platform linux/arm64
+VOLUME2=$(mktemp -d -p "$WORKDIR")
+podman build -v "${VOLUME2}:/root:Z" -f Containerfile-$OS-arm64 --platform linux/arm64
 
 # create and add netboot artifacts for arm64 to the image index
 podman manifest add --annotation org.pulpproject.netboot.version=1 \
@@ -28,9 +30,10 @@ podman manifest add --annotation org.pulpproject.netboot.version=1 \
     --artifact \
     --artifact-type application/vnd.org.pulpproject.netboot.artifact.v1 \
     --artifact-layer-type application/x-netboot-file \
-    quay.io/foreman/nboci-files:$OSVER ./work/*
+    quay.io/foreman/nboci-files:$OSVER "$VOLUME2"/*
 
-rm -rf ./work/
+rm -rf "$WORKDIR"
+
 # push image index containing netboot artifacts for different arches
 podman manifest push --all --rm quay.io/foreman/nboci-files:$OSVER
 


### PR DESCRIPTION
This started as a follow up mentioned in https://github.com/theforeman/nboci-files/pull/                 1#discussion_r1717103883 and while addressing those smaller issues I noticed some chances to make it     generic. This makes it easy to use the script for other Fedora versions or even other distributions.

The rule is now that `Containerfile-$OS-$ARCH` must exist for it to be built. There is no check if       anything exists. Then run the script as
```sh
# Match defaults
OS=fedora VERSION=40 ./push

# Build rawhide
OS=fedora VERSION=rawhide ./push
```

I'll note that I don't have a new enough podman to really test this and verify it.